### PR TITLE
Add 3 utility functions & some typing fixes

### DIFF
--- a/role.ts
+++ b/role.ts
@@ -18,7 +18,10 @@ export type Permissions<Action extends string, Subject extends string> = {
 };
 
 export class Role<Action extends string, Subject extends string> {
-	#permissions = new Map<`${string}:${string}`, boolean>();
+	#permissions = new Map<
+		`${/* action */ string}:${/* subject */ string}`,
+		boolean
+	>();
 	#rawPermissions: RawRole<Action, Subject>[] = [];
 
 	constructor(permissions?: RawRole<Action, Subject>[]) {
@@ -65,8 +68,10 @@ export class Role<Action extends string, Subject extends string> {
 	clone(): Role<Action, Subject> {
 		return new Role(this.getRaw());
 	}
-	extend(permissions: RawRole<Action, Subject>[]): Role<Action, Subject> {
-		return permissions.reduce<Role<Action, Subject>>(
+	extend<Xaction extends string, Xsubject extends string>(
+		permissions: RawRole<Xaction | Action, Xsubject | Subject>[],
+	): Role<Xaction | Action, Xsubject | Subject> {
+		return permissions.reduce<Role<Xaction | Action, Xsubject | Subject>>(
 			(role, [canOrCannot, action, subject]) =>
 				role.set(canOrCannot, action, subject),
 			this.clone(),


### PR DESCRIPTION
# Added functions
## `.extends()` & `.extend()`
typesafe role extension methods
> `extend(permissions)` creates & returns a new role based off of `this.`, with `permissions`
> `extends(...roles)` copies permissions from `roles` to `this.`, returns `this.`

```ts
const baseRole = new Role([
    ['can', 'create', 'reviews']
]) // not used auth, only used for permissions

const reader = baseRole.extend([
    ['can', 'read', 'books']
])

const writer = baseRole.extend([
    ['can', 'create', 'books']
])

const readerAndWriter = new Role().extends(reader, writer)
```

## `.clone()`
Clones `this.` and returns it

# Typing changes

## `.set()` now updates typings of role
Using .set on a role does not give a type error when setting an action or subject that didn't exist at the time of instance construction. `.extends()` & `.extend()` do this as well, since they do `.set()` under the hood
```ts
const user = new Role()

const developer = user.clone().set('can', 'create', 'app')

const admin = developer.clone().set('can', 'update', 'developers')
```

## `.#permissions` is no longer typed by `Action:Subject`, but `string:string`
This was not needed internally, and was removed to support the new `.set()` typing changes